### PR TITLE
Set timestamp transport option

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -8,7 +8,8 @@ module.exports = () => (new winston.Logger({
     'level': 'debug',
     'handleExceptions': false,
     'json': false,
-    'colorize': true
+    'colorize': true,
+    'timestamp': true,
   })],
   'exitOnError': false
 }))


### PR DESCRIPTION
When viewing logs under a running pm2 instance (using `pm2 logs`) the Node application logs are not timestamped by pm2.

This is to see timestamps from the server's incoming requests, API invitations, and database actions.
