### PR TITLE
Database port config

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,7 +7,8 @@ exports.server = {
 
 exports.mongodb = {
   'address': process.env.MONGODB_URL || 'localhost',
-  'database': process.env.MONGODB_DATABASE || 'dvcoders'
+  'database': process.env.MONGODB_DATABASE || 'dvcoders',
+  'port': process.env.MONGODB_PORT || '27017'
 }
 
 // Config for the rendering client

--- a/database.js
+++ b/database.js
@@ -2,10 +2,10 @@
 
 let mongoose = require('mongoose')
 let config = require('./config').mongodb
-mongoose.connect(`mongodb://${config.address}/${config.database}`)
+mongoose.connect(`mongodb://${config.address}:${config.port}/${config.database}`)
 let db = mongoose.connection
 
-module.exports = cb => {
+module.exports = (cb) => {
   db.on('error', cb)
   db.once('open', () => {
     // Register the models in Mongoose


### PR DESCRIPTION
Allow mongo and node server to connect to an arbitrary port using `MONGODB_PORT` env variable.
