### PR TITLE
Lowercase emails and default form field values

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -73,7 +73,7 @@ module.exports = (app, logger) => {
       firstName: body.firstName,
       lastName: body.lastName,
       studentId: body.studentId,
-      email: body.email,
+      email: body.email.toLowerCase(),
       mailchimp: !!body.mailchimp, // Convert to boolean if not already
       github: body.githubUsername
     }

--- a/routes.js
+++ b/routes.js
@@ -31,7 +31,7 @@ module.exports = (app, logger) => {
     // Github actions
     logger.info('Request body', req.body)
     let response = JSON.parse(ajaxResponse) // Get a copy
-    let githubUsername = req.body.githubUsername
+    let githubUsername = req.body.githubUsername || ''
 
     if (githubUsername === '') {
       next()
@@ -70,12 +70,12 @@ module.exports = (app, logger) => {
     let body = req.body
 
     let userObj = {
-      firstName: body.firstName,
-      lastName: body.lastName,
-      studentId: body.studentId,
-      email: body.email.toLowerCase(),
+      firstName: body.firstName || '',
+      lastName: body.lastName || '',
+      studentId: body.studentId || '',
+      email: (body.email || '').toLowerCase(),
       mailchimp: !!body.mailchimp, // Convert to boolean if not already
-      github: body.githubUsername
+      github: body.githubUsername || ''
     }
 
     // Search for the user email.


### PR DESCRIPTION
Changes all emails to save in lowercase. I was looking through the database and saw someone signed up twice for some reason, and they used one email was all lowercase and the other had a capital letter. These are the same emails, so we should just store them as the same.

- [ ] **We will still need to go through the database for existing users and update them if need be.**

Also, I added defaults for form fields, so for example if someone decides to sign up by sending a POST request to the server via some other means than the website, ex `curl`, and forget a field then it shouldn't error. I tried this and I got an error, `MongoDB: CastError: Cast to number failed for value "undefined" at path "studentId"` when only sending firstName. Seems like there should be a better way to do this (using the `|| ''`), so if anyone knows, I'm all ears.

This would also fix trying to sign [`undefined`](https://github.com/undefined) up to our GitHub org.